### PR TITLE
feat: allow custom download folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ Before using the package, ensure you have the `IP2LOCATION_TOKEN` environment va
 Here's a simple example of how to use `easyi2l`:
 
 ```python
+from pathlib import Path
+
 from easyi2l import EasyI2L, DBType
 
 
+# Download to the default folder
 db = EasyI2L.download(DBType.DB11LITEBIN).load()
+
+# Or specify a custom download folder
+# db = EasyI2L.download(DBType.DB11LITEBIN, folder=Path("./ipdb")).load()
 
 # Retrieve all data for an IP address
 print(db.get_all("1.1.1.1"))

--- a/easyi2l/db.py
+++ b/easyi2l/db.py
@@ -1,12 +1,15 @@
 import IP2Location
+from pathlib import Path
 
 from easyi2l.config import db_folder
 
 
 class EasyI2LDB:
-    def __init__(self, database_code):
+    def __init__(self, database_code, folder: Path = db_folder):
         self.database_code = database_code
+        self.folder = Path(folder)
         self.database_file = None
 
     def load(self) -> IP2Location.IP2Location:
-        return IP2Location.IP2Location(f"{db_folder}/{self.database_code}")
+        return IP2Location.IP2Location(str(self.folder / self.database_code))
+

--- a/easyi2l/easyi2l.py
+++ b/easyi2l/easyi2l.py
@@ -13,23 +13,26 @@ from easyi2l.logger import logging
 
 class EasyI2L:
     @staticmethod
-    def download(database_code: DBType, api_key: str = None) -> EasyI2LDB:
+    def download(database_code: DBType, api_key: str = None, folder: Path = None) -> EasyI2LDB:
+        download_folder = Path(folder) if folder else db_folder
+        download_folder.mkdir(parents=True, exist_ok=True)
+
         # If the file already exists and is a file and is not older than 30 days, return the file
         if (
-                (db_folder / database_code["file"]).exists() and
-                (db_folder / database_code["file"]).is_file() and
-                (db_folder / f"{database_code['file']}.timestamp").exists() and
-                (db_folder / f"{database_code['file']}.timestamp").is_file() and
+                (download_folder / database_code["file"]).exists() and
+                (download_folder / database_code["file"]).is_file() and
+                (download_folder / f"{database_code['file']}.timestamp").exists() and
+                (download_folder / f"{database_code['file']}.timestamp").is_file() and
                 (time.time() - float(
-                    (db_folder / f"{database_code['file']}.timestamp").read_text()) < 30 * 24 * 60 * 60)
+                    (download_folder / f"{database_code['file']}.timestamp").read_text()) < 30 * 24 * 60 * 60)
         ):
             logging.info(f"Using existing {database_code['file']}")
-            return EasyI2LDB(database_code["file"])
+            return EasyI2LDB(database_code["file"], download_folder)
         else:
-            if (db_folder / database_code["file"]).exists():
-                (db_folder / database_code["file"]).unlink()
-            if (db_folder / f"{database_code['file']}.timestamp").exists():
-                (db_folder / f"{database_code['file']}.timestamp").unlink()
+            if (download_folder / database_code["file"]).exists():
+                (download_folder / database_code["file"]).unlink()
+            if (download_folder / f"{database_code['file']}.timestamp").exists():
+                (download_folder / f"{database_code['file']}.timestamp").unlink()
 
         # Use provided api_key if given, otherwise fallback to config
         token = api_key if api_key is not None else IP2LOCATION_TOKEN
@@ -64,11 +67,11 @@ class EasyI2L:
                         logging.info(f"Extracted {file_info.filename}")
 
                         extracted_file = Path(file_info.filename)
-                        shutil.move(str(extracted_file), str(db_folder / extracted_file.name))
-                        logging.info(f"Moved {extracted_file.name} to {db_folder}")
+                        shutil.move(str(extracted_file), str(download_folder / extracted_file.name))
+                        logging.info(f"Moved {extracted_file.name} to {download_folder}")
 
                         # Create timestamp file
-                        Path(db_folder / f"{extracted_file.name}.timestamp").write_text(str(time.time()))
+                        Path(download_folder / f"{extracted_file.name}.timestamp").write_text(str(time.time()))
 
             logging.info(f"Downloaded and extracted {database_code['code']}.zip")
             Path(f"{database_code['code']}.zip").unlink()
@@ -77,4 +80,4 @@ class EasyI2L:
             raise ValueError(
                 f"Failed to download {database_code['code']}.zip\n\tUrl: {url}\n\tCode: {response.status_code}")
 
-        return EasyI2LDB(database_code['file'])
+        return EasyI2LDB(database_code['file'], download_folder)


### PR DESCRIPTION
## Summary
- allow specifying custom download folder when retrieving IP2Location data
- support custom folder in database loader
- document custom download directory usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install IP2Location` *(fails: Could not find a version that satisfies the requirement IP2Location)*

------
https://chatgpt.com/codex/tasks/task_e_68988e1233348327acd8452609bc19be